### PR TITLE
#41 Changed Resume Page Body Variants to body1

### DIFF
--- a/src/components/ResumePage/ResumeExperiencesSection.js
+++ b/src/components/ResumePage/ResumeExperiencesSection.js
@@ -48,13 +48,13 @@ const CAMDITDescriptionBullets = [
 function ToolsList(items) {
   return (
     <List>
-      <Typography variant='body2' fontWeight='bold'>
+      <Typography variant='body1' fontWeight='bold'>
         Associated Tools/Skills
       </Typography>
 
       {items.map((bullet) => (
         <ListItemText
-          primaryTypographyProps={{ variant: 'body2' }}
+          primaryTypographyProps={{ variant: 'body1' }}
           key={bullet}
         >
           {bullet}
@@ -69,7 +69,7 @@ function BulletedList(items) {
     <List sx={{ listStyleType: 'disc' }}>
       {items.map((bullet) => (
         <ListItemText
-          primaryTypographyProps={{ variant: 'body2' }}
+          primaryTypographyProps={{ variant: 'body1' }}
           sx={{ display: 'list-item' }}
           key={bullet}
         >

--- a/src/components/ResumePage/ResumeGridFormatting.js
+++ b/src/components/ResumePage/ResumeGridFormatting.js
@@ -34,7 +34,7 @@ function ResumeCompanyHeading({ children }) {
 function ResumeLeftGridBody({ children }) {
   return (
     <Grid item xs={6}>
-      <Typography variant='body2' align='right'>
+      <Typography variant='body1' align='right'>
         {children}
       </Typography>
     </Grid>
@@ -44,7 +44,7 @@ function ResumeLeftGridBody({ children }) {
 function ResumeRightGridBody({ children }) {
   return (
     <Grid item xs={6}>
-      <Typography variant='body2' align='left'>
+      <Typography variant='body1' align='left'>
         {children}
       </Typography>
     </Grid>

--- a/src/components/layout/Footer.js
+++ b/src/components/layout/Footer.js
@@ -18,7 +18,7 @@ const links = [
 export default function Footer() {
   return (
     <footer>
-      <Grid container>
+      <Grid container sx={{ pb: 2 }}>
         <Grid item xs={3} />
         <Grid item xs={9}>
           <Box sx={{ display: 'flex', justifyContent: 'end' }}>

--- a/theme.js
+++ b/theme.js
@@ -36,7 +36,7 @@ const theme = createTheme({
       fontWeight: 'normal',
       color: 'secondary',
     },
-    body2: { fontSize: '24px' },
+    body1: { fontSize: '20px' },
   },
   components: {
     MuiButton: {


### PR DESCRIPTION
## Changes/Notes
- Changed the body typography in the resume from body2 to body1
- Changed the theme override to change the size of body1 instead of body2, adjusted to 20px font size to be a little smaller
-
## Screenshots
<img width="936" alt="image" src="https://github.com/sharonyang16/personal-website/assets/92332953/6eab6c1a-01bf-4555-8e63-eced8e36c822">

<img width="799" alt="image" src="https://github.com/sharonyang16/personal-website/assets/92332953/954b0f34-faf8-4ee4-9053-400f2b37ff8d">

<img width="414" alt="image" src="https://github.com/sharonyang16/personal-website/assets/92332953/b9f20d20-35d5-4fcf-b4f7-271c4065cbbd">

## To Do

- [x] Add a little bottom padding to the footer

Closes #41
