### PR TITLE
Add Home Page Content

### DIFF
--- a/src/content/code.json
+++ b/src/content/code.json
@@ -1,0 +1,41 @@
+[
+  {
+    "id": 0,
+    "title": "Personal Website",
+    "url": "https://sharonyang16.github.io/",
+    "description": "This website!",
+    "technologies": ["React", "Next.js", "TypeScript", "Tailwind CSS"]
+  },
+  {
+    "id": 1,
+    "title": "Mock Stack Overflow App",
+    "url": "https://cs4530-s25-404.onrender.com/",
+    "description": "A full-stack Stack Overflow clone with added Single Sign-On (SSO) authentication and natural language searching features. Built for Northeastern University's CS4530: Fundamentals of Software Engineering.",
+    "technologies": ["React", "TypeScript", "MongoDB", "Jest"]
+  },
+  {
+    "id": 2,
+    "title": "Timbers' Nap",
+    "description": "3D-platformer with 3 engaging levels. Built for Northeastern University's CS3540: Game Programming.",
+    "technologies": ["Unity3D", "C#"]
+  },
+  {
+    "id": 3,
+    "title": "Vet Finder",
+    "description": "A user-friendly vet finder app. Built for and awarded 1st place at Chewy's 2023 Diversity Hackathon.",
+    "technologies": ["React", "Next.js", "JavaScript", "Tailwind CSS"]
+  },
+  {
+    "id": 4,
+    "title": "FinishLine",
+    "url": "https://finishlinebyner.com",
+    "description": "Internal project management dashboard for Northeastern Electric Racing",
+    "technologies": ["React", "TypeScript", "Express.js", "Prisma", "Jest"]
+  },
+  {
+    "id": 5,
+    "title": "Image Processor",
+    "description": "Image processing and manipulation app with various filters. Built for Northeastern University's CS3500: Object-Oriented Design.",
+    "technologies": ["Java", "JUnit", "Java Swing"]
+  }
+]

--- a/src/content/code.json
+++ b/src/content/code.json
@@ -2,7 +2,7 @@
   {
     "id": 0,
     "title": "Personal Website",
-    "url": "https://sharonyang16.github.io/",
+    "url": "https://github.com/sharonyang16/sharonyang16.github.io",
     "description": "This website!",
     "technologies": ["React", "Next.js", "TypeScript", "Tailwind CSS"]
   },
@@ -16,12 +16,14 @@
   {
     "id": 2,
     "title": "Timbers' Nap",
+    "url": "https://play.unity.com/mg/other/webgl-builds-349008",
     "description": "3D-platformer with 3 engaging levels. Built for Northeastern University's CS3540: Game Programming.",
     "technologies": ["Unity3D", "C#"]
   },
   {
     "id": 3,
     "title": "Vet Finder",
+    "url": "https://github.com/chanmioh/team-animal",
     "description": "A user-friendly vet finder app. Built for and awarded 1st place at Chewy's 2023 Diversity Hackathon.",
     "technologies": ["React", "Next.js", "JavaScript", "Tailwind CSS"]
   },
@@ -35,6 +37,7 @@
   {
     "id": 5,
     "title": "Image Processor",
+    "url": "https://github.com/sharonyang16/image-processing",
     "description": "Image processing and manipulation app with various filters. Built for Northeastern University's CS3500: Object-Oriented Design.",
     "technologies": ["Java", "JUnit", "Java Swing"]
   }

--- a/src/content/design.json
+++ b/src/content/design.json
@@ -8,7 +8,7 @@
   {
     "id": 1,
     "title": "Apple Maps Explore",
-    "description": "A new apple maps feature focused on exploring new places and making navigation an adventure.  Designed for Northeastern University's ARTG2400: Interaction Design Principles.",
+    "description": "A new apple maps feature focused on exploring new places and making navigation an adventure. Designed for Northeastern University's ARTG2400: Interaction Design Principles.",
     "technologies": ["Figma", "User Research"]
   },
   {
@@ -26,19 +26,19 @@
   {
     "id": 4,
     "title": "FinishLine CAD File Review System",
-    "description": "",
+    "description": "New feature to help engineers review each others CAD files easier and within the interal project management dashboard.",
     "technologies": ["Figma", "User Research"]
   },
   {
     "id": 5,
     "title": "FinishLine Home Page Revamp",
-    "description": "",
+    "description": "Redesigned the home page of the internal project management dashboard to be more useful for members of different roles.",
     "technologies": ["Figma", "User Research"]
   },
   {
     "id": 6,
     "title": "Argos Dashboard Revamp",
-    "description": "",
+    "description": "Redesigned the home page of the car data visualization dashboard to have a more interesting and modular design.",
     "technologies": ["Figma", "User Research"]
   }
 ]

--- a/src/content/design.json
+++ b/src/content/design.json
@@ -1,0 +1,44 @@
+[
+  {
+    "id": 0,
+    "title": "Oven Buddy",
+    "description": "Uber inspired smart oven app. Designed for Northeastern University's ARTG2400: Interaction Design Principles.",
+    "technologies": ["Figma", "User Research"]
+  },
+  {
+    "id": 1,
+    "title": "Apple Maps Explore",
+    "description": "A new apple maps feature focused on exploring new places and making navigation an adventure.  Designed for Northeastern University's ARTG2400: Interaction Design Principles.",
+    "technologies": ["Figma", "User Research"]
+  },
+  {
+    "id": 2,
+    "title": "NUSkillz",
+    "description": "Social media app for developing new skills, focusing on connecting users with like-minded peers. Designed for Northeastern University's IS4300: Human Computer Interaction.",
+    "technologies": ["Figma", "User Research"]
+  },
+  {
+    "id": 3,
+    "title": "FinishLine Guest Mode/Mobile",
+    "description": "Focused on transforming existing project managmenet dashboard UI to be more useful for passing viewers and more responsive on smaller screens.",
+    "technologies": ["Figma", "User Research"]
+  },
+  {
+    "id": 4,
+    "title": "FinishLine CAD File Review System",
+    "description": "",
+    "technologies": ["Figma", "User Research"]
+  },
+  {
+    "id": 5,
+    "title": "FinishLine Home Page Revamp",
+    "description": "",
+    "technologies": ["Figma", "User Research"]
+  },
+  {
+    "id": 6,
+    "title": "Argos Dashboard Revamp",
+    "description": "",
+    "technologies": ["Figma", "User Research"]
+  }
+]

--- a/src/content/experience.json
+++ b/src/content/experience.json
@@ -14,7 +14,8 @@
     "position": "Software Product Lead",
     "start": "2023-12-01",
     "end": "2024-12-31",
-    "description": "Lead teams of product designers and managers to develop new features for internal project management and data visualization dashboards, working closely with users to create high-fidelity wireframes."
+    "description": "Lead teams of product designers and managers to develop new features for internal project management and data visualization dashboards, working closely with users to create high-fidelity wireframes.",
+    "technologies": ["Figma", "Wireframing", "User Research"]
   },
   {
     "id": 2,

--- a/src/content/experience.json
+++ b/src/content/experience.json
@@ -1,0 +1,37 @@
+[
+  {
+    "id": 0,
+    "company": "Priceline",
+    "position": "Software Engineer Co-op",
+    "start": "2024-07-01",
+    "end": "2024-12-31",
+    "description": "Developed in an Agile frontend team, working closely with designers to deliver responsive UI features, managing deployments, and providing support for an authentication migration. ",
+    "technologies": ["React", "Next.js", "TypeScript", "GraphQL", "Jest"]
+  },
+  {
+    "id": 1,
+    "company": "Northeastern Electric Racing",
+    "position": "Software Product Lead",
+    "start": "2023-12-01",
+    "end": "2024-12-31",
+    "description": "Lead teams of product designers and managers to develop new features for internal project management and data visualization dashboards, working closely with users to create high-fidelity wireframes."
+  },
+  {
+    "id": 2,
+    "company": "Northeastern Electric Racing",
+    "position": "Software Developer",
+    "start": "2023-09-01",
+    "end": "2024-12-31",
+    "description": "Contributed to open-source full-stack internal project management dashboard.",
+    "technologies": ["React", "TypeScript", "Express.js", "Prisma", "Jest"]
+  },
+  {
+    "id": 3,
+    "company": "CAMD at Northeastern University",
+    "position": "IT/Audio Visual Co-op",
+    "start": "2023-07-01",
+    "end": "2023-12-31",
+    "description": "Provided technical support for students, faculty, and staff regarding software and hardware and maintained departmental equipment.",
+    "technologies": ["ServiceNow", "Troubleshooting"]
+  }
+]

--- a/src/content/experience.json
+++ b/src/content/experience.json
@@ -15,7 +15,7 @@
     "start": "2023-12-01",
     "end": "2024-12-31",
     "description": "Lead teams of product designers and managers to develop new features for internal project management and data visualization dashboards, working closely with users to create high-fidelity wireframes.",
-    "technologies": ["Figma", "Wireframing", "User Research"]
+    "technologies": ["Figma", "User Research"]
   },
   {
     "id": 2,

--- a/src/types/data.d.ts
+++ b/src/types/data.d.ts
@@ -1,0 +1,24 @@
+export type Experience = {
+  id: number;
+  company: string;
+  position: string;
+  start: string;
+  end: string;
+  description: string;
+  technologies: string[];
+};
+
+export type CodeProject = {
+  id: number;
+  title: string;
+  url: string;
+  description: string;
+  technologies: string[];
+};
+
+export type DesignProject = {
+  id: number;
+  title: string;
+  description: string;
+  technologies: string[];
+};


### PR DESCRIPTION
### Changes
- Added `json` files for home page data (i.e. experiences and coding and design projects)
- Preemptively added types for later use

### Todo: 
- [x] add descriptions for design projects
- [x] add links to coding projects

Closes #6