### PR TITLE
Create Button Component

### DIFF
--- a/src/components/base/Button.tsx
+++ b/src/components/base/Button.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { VariantProps, cva } from "class-variance-authority";
+import { cn } from "./utils";
+
+const buttonVariants = cva(
+  "p-2 rounded-lg cursor-pointer disabled:cursor-not-allowed disabled:opacity-50",
+  {
+    variants: {
+      variant: {
+        primary:
+          "bg-black text-white enabled:hover:bg-gray-800 enabled:active:bg-gray-800 enabled:focus:bg-gray-800",
+        secondary:
+          "border-1 border-black enabled:hover:bg-gray-100 enabled:active:bg-gray-100 enabled:focus:bg-gray-100",
+      },
+    },
+    defaultVariants: {
+      variant: "primary",
+    },
+  }
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  as?: string;
+}
+
+const Button = React.forwardRef<HTMLElement, ButtonProps>(
+  ({ variant, className, as, ...props }, ref) => {
+    const componentProps = {
+      className: cn(buttonVariants({ variant, className })),
+      ...props,
+      ref,
+    };
+
+    if (as === "a") {
+      return React.createElement(as, componentProps);
+    }
+    return React.createElement("button", componentProps);
+  }
+);
+
+Button.displayName = "Button";
+
+export default Button;


### PR DESCRIPTION
### Changes
- Added button component
- Should add `icon` and `iconLeft` props in the future, but keeping it simple for now
- Ideally should have a `Link` component too that can be styled as a button, but keeping it simple for now (future technical improvement)

Closes #5